### PR TITLE
Fix DB connection leak and parameterize stats query

### DIFF
--- a/API/Persistence/MapperStatistics.cs
+++ b/API/Persistence/MapperStatistics.cs
@@ -64,7 +64,7 @@ namespace API.Persistence
             MySqlConnection con = new MySqlConnection(_conString);
             con.Open();
             MySqlCommand cmd;
-            _sql = "SELECT count(*) FROM tickets LEFT JOIN priority ON tickets.priority_PriorityID = priority.PriorityID INNER JOIN users on tickets.ByUser = users.User_id WHERE priority.PriorityName = 'Critical' and tickets.ByUser  and users.company_CompanyID = (select company_CompanyID from users where User_id = 63)";
+            _sql = "SELECT count(*) FROM tickets LEFT JOIN priority ON tickets.priority_PriorityID = priority.PriorityID INNER JOIN users on tickets.ByUser = users.User_id WHERE priority.PriorityName = 'Critical' and tickets.ByUser  and users.company_CompanyID = (select company_CompanyID from users where User_id = @UID)";
             cmd = new MySqlCommand(_sql, con);
             cmd.Parameters.Add(new MySqlParameter("@UID", UID));
             try

--- a/API/Persistence/MapperTicketAttributes.cs
+++ b/API/Persistence/MapperTicketAttributes.cs
@@ -102,6 +102,7 @@ namespace API.Persistence
             cmd = new MySqlCommand(_sql, con);
             cmd.Parameters.Add(new MySqlParameter("@CAT", Cat));
             cmd.ExecuteNonQuery();
+            con.Close();
         }
         public void PermanentlyDelete_DeleteComments(int UID)
         {


### PR DESCRIPTION
## Summary
- close MySql connection when adding a new category
- parameterize the critical ticket statistics query

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844000bdf288325bd7ece0220cabe4e